### PR TITLE
feat: opt-in TTL eviction for unused label combinations

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,3 +62,27 @@ Run the container
 ```
 docker run -it -v ./gitlab.yaml:/gitlab-yaml --rm -p 9353:9353 registry.ubble.ai/ubbleai/sandbox/graphql-exporter:dev
 ```
+
+## Unused label eviction
+
+GraphQL responses with high-cardinality fields (e.g. GitLab `pipeline_ref`, `job_name`) cause the in-process Prometheus vecs to accumulate label combinations that never reappear (deleted MRs, retired jobs). Set `unusedLabelTTLSeconds` to evict a label child once it has not been seen by a successful scrape for that duration.
+
+```yaml
+unusedLabelTTLSeconds: 21600   # 6h; 0 (default) disables eviction
+```
+
+Behaviour:
+
+- Eviction runs at the end of each **successful** scrape (skipped if the underlying GraphQL query errored — no purge on transient outages).
+- Per-child: only stale series are removed. Active counters keep their accumulated value across scrapes; only series that have not been seen for `unusedLabelTTLSeconds` are dropped.
+- Counter resets: when an evicted label combination reappears, its counter restarts at zero. PromQL `rate()` / `increase()` handle counter resets natively.
+- Zero-dimension metrics (no labels) are not tracked — there is at most one child.
+
+The exporter exposes two observability metrics under the `ubbleai_graphql_exporter_exporter_` prefix:
+
+| Metric | Type | Meaning |
+|--------|------|---------|
+| `ubbleai_graphql_exporter_exporter_evicted_labels_total{metric}` | counter | label combinations removed by the TTL policy |
+| `ubbleai_graphql_exporter_exporter_tracked_labels{metric}` | gauge | current size of the label-last-seen map (steady-state cardinality) |
+
+When `unusedLabelTTLSeconds=0` the two metrics emit no series (the eviction code never runs).

--- a/charts/graphql-exporter/Chart.yaml
+++ b/charts/graphql-exporter/Chart.yaml
@@ -15,10 +15,10 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.1.5
+version: 0.1.6
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to
 # follow Semantic Versioning. They should reflect the version the application is using.
 # It is recommended to use it with quotes.
-appVersion: "1.0.3"
+appVersion: "1.0.4"

--- a/config_example.yaml
+++ b/config_example.yaml
@@ -6,6 +6,7 @@ cacheExpire: 0
 queryTimeout: 60
 failFast: false
 extendCacheOnError: false
+# unusedLabelTTLSeconds: 21600   # evict label combinations not seen for N seconds (0 = disabled)
 queries:
 - query: query {device_list {name serial custom_fields}} {{NOW "-1h"}}
   metrics:

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -47,6 +47,12 @@ type Metric struct {
 	Name             string    `yaml:"name"`
 }
 
+// PrometheusNamespace is the fixed Prometheus namespace used by the exporter's own observability
+// metrics (evicted_labels_total, tracked_labels). It is intentionally a compile-time constant so
+// it can be referenced at package-init time (promauto), before Init() runs. User metrics use
+// Cfg.MetricsPrefix, which is configurable and may differ if redeployed elsewhere.
+const PrometheusNamespace = "ubbleai_graphql_exporter"
+
 var (
 	Config     *Cfg
 	ConfigPath string

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -20,6 +20,10 @@ type Cfg struct {
 	ExtendCacheOnError  bool    `yaml:"extendCacheOnError"`
 	Queries             []Query `yaml:"queries"`
 	DisableTimestamp    bool    `yaml:"disableTimestamp"`
+	// UnusedLabelTTLSeconds removes a label combination from the Prometheus vec if it was not
+	// updated in any successful scrape for this long. 0 disables eviction. This drops stale
+	// series without resetting entire vecs (unlike Reset), so active counters/histograms keep state.
+	UnusedLabelTTLSeconds int64 `yaml:"unusedLabelTTLSeconds"`
 }
 
 type Query struct {
@@ -74,6 +78,11 @@ func Init(configPath string) error {
 
 	if Config.QueryTimeout == 0 {
 		Config.QueryTimeout = 60
+	}
+
+	if Config.UnusedLabelTTLSeconds > 0 {
+		slog.Info("unused label eviction enabled",
+			"unusedLabelTTLSeconds", Config.UnusedLabelTTLSeconds)
 	}
 
 	slog.Info(fmt.Sprintf("Finished reading config from %s", configPath))

--- a/internal/prometheus/collector.go
+++ b/internal/prometheus/collector.go
@@ -130,13 +130,17 @@ func newGraphqlCollector() *GraphqlCollector {
 					labelNames,
 				)
 			}
+			var lastSeen map[string]time.Time
+			if len(labelNames) > 0 {
+				lastSeen = make(map[string]time.Time)
+			}
 			metrics = append(metrics, &Metric{
 				Collector:     collector,
 				Name:          name,
 				LabelNames:    labelNames,
 				Config:        m,
 				Extractor:     extractor,
-				labelLastSeen: make(map[string]time.Time),
+				labelLastSeen: lastSeen,
 			})
 		}
 		querySet := &QuerySet{
@@ -233,7 +237,7 @@ func (collector *GraphqlCollector) getMetrics() error {
 				default:
 					slog.Error(fmt.Sprintf("unsuported collector type %v", v))
 				}
-				if ttl > 0 && updated {
+				if ttl > 0 && updated && m.labelLastSeen != nil {
 					if sk := labelsToStorageKey(m.LabelNames, labels); sk != "" {
 						m.labelLastSeen[sk] = sampleNow
 					} else {

--- a/internal/prometheus/collector.go
+++ b/internal/prometheus/collector.go
@@ -28,9 +28,31 @@ type QuerySet struct {
 
 type Metric struct {
 	Collector prometheus.Collector
-	Labels    []string
-	Config    config.Metric
-	Extractor Extractor
+	// LabelNames are Prometheus vec label names in callback / WithLabelValues order (sorted extractor aliases).
+	LabelNames []string
+	Config     config.Metric
+	Extractor  Extractor
+	// labelLastSeen records the last time this label set was updated from GraphQL (success path).
+	labelLastSeen map[string]time.Time
+}
+
+// evictStaleLabels removes vec children whose last update is older than ttl.
+func (m *Metric) evictStaleLabels(now time.Time, ttl time.Duration) {
+	if ttl <= 0 || len(m.labelLastSeen) == 0 {
+		return
+	}
+	var dead []string
+	for key, t := range m.labelLastSeen {
+		if now.Sub(t) >= ttl {
+			dead = append(dead, key)
+		}
+	}
+	for _, key := range dead {
+		if lvs := labelValuesFromStorageKey(m.LabelNames, key); lvs != nil {
+			vecDeleteLabelValues(m.Collector, lvs)
+		}
+		delete(m.labelLastSeen, key)
+	}
 }
 
 type GraphqlCollector struct {
@@ -105,9 +127,11 @@ func newGraphqlCollector() *GraphqlCollector {
 				)
 			}
 			metrics = append(metrics, &Metric{
-				Collector: collector,
-				Config:    m,
-				Extractor: extractor,
+				Collector:     collector,
+				LabelNames:    labelNames,
+				Config:        m,
+				Extractor:     extractor,
+				labelLastSeen: make(map[string]time.Time),
 			})
 		}
 		querySet := &QuerySet{
@@ -170,12 +194,15 @@ func (collector *GraphqlCollector) getMetrics() error {
 			continue
 		}
 		slog.Debug(fmt.Sprintf("data found %+v", data))
+		ttl := time.Duration(config.Config.UnusedLabelTTLSeconds) * time.Second
 		for _, m := range q.Metrics {
 			metricCtx := context.WithValue(queryCtx, "metric", m.Config.Name)
+			sampleNow := time.Now()
 			callbackFunc := func(value string, labels []string) {
 				if value == "" || value == "<nil>" {
 					return
 				}
+				updated := false
 				switch v := m.Collector.(type) {
 				case *prometheus.HistogramVec:
 					f, err := strconv.ParseFloat(value, 64)
@@ -183,23 +210,37 @@ func (collector *GraphqlCollector) getMetrics() error {
 						slog.ErrorContext(metricCtx, "fail to convert metric to float", slog.String("value", value))
 					}
 					v.WithLabelValues(labels...).Observe(f)
+					updated = true
 				case *prometheus.GaugeVec:
 					f, err := strconv.ParseFloat(value, 64)
 					if err != nil {
 						slog.ErrorContext(metricCtx, "fail to convert metric to float", slog.String("value", value))
 					}
 					v.WithLabelValues(labels...).Set(f)
+					updated = true
 				case *prometheus.CounterVec:
 					f, err := strconv.ParseFloat(value, 64)
 					if err != nil || f < 0 {
 						f = 1
 					}
 					v.WithLabelValues(labels...).Add(f)
+					updated = true
 				default:
 					slog.Error(fmt.Sprintf("unsuported collector type %v", v))
 				}
+				if ttl > 0 && updated {
+					if sk := labelsToStorageKey(m.LabelNames, labels); sk != "" {
+						m.labelLastSeen[sk] = sampleNow
+					} else {
+						slog.ErrorContext(metricCtx, "label cardinality mismatch for unused-label tracking",
+							slog.Int("labelNames", len(m.LabelNames)), slog.Int("labelValues", len(labels)))
+					}
+				}
 			}
 			m.Extractor.ExtractMetrics(data, callbackFunc)
+			if ttl > 0 {
+				m.evictStaleLabels(sampleNow, ttl)
+			}
 		}
 	}
 	return nil

--- a/internal/prometheus/collector.go
+++ b/internal/prometheus/collector.go
@@ -40,7 +40,10 @@ type Metric struct {
 	labelLastSeen map[string]time.Time
 }
 
-// evictStaleLabels removes vec children whose last update is older than ttl.
+// evictStaleLabels removes vec children whose last update is older than ttl, then updates the
+// exporter's own observability metrics.
+//
+// Must be called under GraphqlCollector.accessMu (which serializes Collect and getMetrics).
 func (m *Metric) evictStaleLabels(now time.Time, ttl time.Duration) {
 	if ttl <= 0 || len(m.labelLastSeen) == 0 {
 		return
@@ -57,6 +60,10 @@ func (m *Metric) evictStaleLabels(now time.Time, ttl time.Duration) {
 		}
 		delete(m.labelLastSeen, key)
 	}
+	if len(dead) > 0 {
+		evictedTotal.WithLabelValues(m.Name).Add(float64(len(dead)))
+	}
+	trackedLabels.WithLabelValues(m.Name).Set(float64(len(m.labelLastSeen)))
 }
 
 type GraphqlCollector struct {

--- a/internal/prometheus/collector.go
+++ b/internal/prometheus/collector.go
@@ -254,7 +254,7 @@ func (collector *GraphqlCollector) getMetrics() error {
 				}
 			}
 			m.Extractor.ExtractMetrics(data, callbackFunc)
-			if ttl > 0 {
+			if ttl > 0 && len(gql.Errors) == 0 {
 				m.evictStaleLabels(sampleNow, ttl)
 			}
 		}

--- a/internal/prometheus/collector.go
+++ b/internal/prometheus/collector.go
@@ -28,6 +28,10 @@ type QuerySet struct {
 
 type Metric struct {
 	Collector prometheus.Collector
+	// Name is the resolved Prometheus metric name within its subsystem (user-supplied m.Name,
+	// or derived from m.Value when m.Name is empty). Used as the disambiguating label on the
+	// exporter's own observability vecs.
+	Name string
 	// LabelNames are Prometheus vec label names in callback / WithLabelValues order (sorted extractor aliases).
 	LabelNames []string
 	Config     config.Metric
@@ -128,6 +132,7 @@ func newGraphqlCollector() *GraphqlCollector {
 			}
 			metrics = append(metrics, &Metric{
 				Collector:     collector,
+				Name:          name,
 				LabelNames:    labelNames,
 				Config:        m,
 				Extractor:     extractor,

--- a/internal/prometheus/collector_test.go
+++ b/internal/prometheus/collector_test.go
@@ -138,3 +138,25 @@ func TestEvictStaleLabels_ZeroDimensionSkipped(t *testing.T) {
 		m.evictStaleLabels(time.Now(), time.Minute)
 	})
 }
+
+func TestZeroDimensionGuard_WritePathSkipsNilMap(t *testing.T) {
+	t.Parallel()
+	// Simulate the inner block of getMetrics() with a zero-dim metric: nil map should not panic
+	// and should not be populated.
+	m := &Metric{
+		LabelNames:    nil,
+		Name:          "test_zero_dim_write",
+		labelLastSeen: nil,
+	}
+	// Mirror the production guard: only stamp if map is non-nil.
+	stamp := func(labels []string) {
+		if m.labelLastSeen == nil {
+			return
+		}
+		sk := labelsToStorageKey(m.LabelNames, labels)
+		require.NotEmpty(t, sk)
+		m.labelLastSeen[sk] = time.Now()
+	}
+	require.NotPanics(t, func() { stamp(nil) })
+	require.Nil(t, m.labelLastSeen)
+}

--- a/internal/prometheus/collector_test.go
+++ b/internal/prometheus/collector_test.go
@@ -139,6 +139,53 @@ func TestEvictStaleLabels_ZeroDimensionSkipped(t *testing.T) {
 	})
 }
 
+func readCounter(c prometheus.Counter) float64 {
+	pb := &dto.Metric{}
+	if err := c.Write(pb); err != nil {
+		return -1
+	}
+	return pb.GetCounter().GetValue()
+}
+
+func readGauge(g prometheus.Gauge) float64 {
+	pb := &dto.Metric{}
+	if err := g.Write(pb); err != nil {
+		return -1
+	}
+	return pb.GetGauge().GetValue()
+}
+
+func TestEvictStaleLabels_UpdatesObservabilityMetrics(t *testing.T) {
+	// Cannot use t.Parallel() — touches package-level promauto vecs whose state would race
+	// with other tests on the same metric label.
+	const metricName = "test_obs_metric_uniq"
+	g := prometheus.NewGaugeVec(prometheus.GaugeOpts{Name: "test_obs", Help: "h"}, []string{"job"})
+
+	names := []string{"job"}
+	now := time.Now()
+	skKeep := labelsToStorageKey(names, []string{"keep"})
+	skDrop := labelsToStorageKey(names, []string{"drop"})
+
+	m := &Metric{
+		Collector:  g,
+		Name:       metricName,
+		LabelNames: names,
+		labelLastSeen: map[string]time.Time{
+			skKeep: now.Add(-time.Minute),
+			skDrop: now.Add(-time.Hour),
+		},
+	}
+	g.WithLabelValues("keep").Set(1)
+	g.WithLabelValues("drop").Set(1)
+
+	evictedBefore := readCounter(evictedTotal.WithLabelValues(metricName))
+
+	m.evictStaleLabels(now, 30*time.Minute)
+
+	require.Equal(t, evictedBefore+1, readCounter(evictedTotal.WithLabelValues(metricName)))
+	require.Equal(t, 1.0, readGauge(trackedLabels.WithLabelValues(metricName)))
+}
+
 func TestZeroDimensionGuard_WritePathSkipsNilMap(t *testing.T) {
 	t.Parallel()
 	// Simulate the inner block of getMetrics() with a zero-dim metric: nil map should not panic

--- a/internal/prometheus/collector_test.go
+++ b/internal/prometheus/collector_test.go
@@ -1,0 +1,140 @@
+package prometheus
+
+import (
+	"testing"
+	"time"
+
+	"github.com/prometheus/client_golang/prometheus"
+	dto "github.com/prometheus/client_model/go"
+	"github.com/stretchr/testify/require"
+)
+
+func TestEvictStaleLabels_CounterVec(t *testing.T) {
+	t.Parallel()
+	c := prometheus.NewCounterVec(prometheus.CounterOpts{Name: "test_evict_counter", Help: "h"}, []string{"job"})
+	reg := prometheus.NewPedanticRegistry()
+	require.NoError(t, reg.Register(c))
+
+	names := []string{"job"}
+	now := time.Now()
+	skKeep := labelsToStorageKey(names, []string{"keep"})
+	skDrop := labelsToStorageKey(names, []string{"drop"})
+	require.NotEmpty(t, skKeep)
+	require.NotEmpty(t, skDrop)
+
+	m := &Metric{
+		Collector:     c,
+		LabelNames:    names,
+		Name:          "test_evict_counter",
+		labelLastSeen: make(map[string]time.Time),
+	}
+	m.labelLastSeen[skKeep] = now.Add(-time.Minute)
+	m.labelLastSeen[skDrop] = now.Add(-time.Hour)
+	c.WithLabelValues("keep").Inc()
+	c.WithLabelValues("drop").Inc()
+	require.Equal(t, 2, countVecMetrics(reg))
+
+	m.evictStaleLabels(now, 30*time.Minute)
+
+	require.Equal(t, 1, countVecMetrics(reg))
+	require.NotContains(t, m.labelLastSeen, skDrop)
+	require.Contains(t, m.labelLastSeen, skKeep)
+}
+
+func TestEvictStaleLabels_HistogramVec(t *testing.T) {
+	t.Parallel()
+	h := prometheus.NewHistogramVec(
+		prometheus.HistogramOpts{Name: "test_evict_hist", Help: "h", Buckets: []float64{1, 2}},
+		[]string{"job"},
+	)
+	reg := prometheus.NewPedanticRegistry()
+	require.NoError(t, reg.Register(h))
+
+	names := []string{"job"}
+	now := time.Now()
+	skKeep := labelsToStorageKey(names, []string{"keep"})
+	skDrop := labelsToStorageKey(names, []string{"drop"})
+
+	m := &Metric{
+		Collector:     h,
+		LabelNames:    names,
+		Name:          "test_evict_hist",
+		labelLastSeen: make(map[string]time.Time),
+	}
+	m.labelLastSeen[skKeep] = now.Add(-time.Minute)
+	m.labelLastSeen[skDrop] = now.Add(-time.Hour)
+	h.WithLabelValues("keep").Observe(1)
+	h.WithLabelValues("drop").Observe(1)
+	require.Equal(t, 2, countVecMetrics(reg))
+
+	m.evictStaleLabels(now, 30*time.Minute)
+
+	require.Equal(t, 1, countVecMetrics(reg))
+	require.NotContains(t, m.labelLastSeen, skDrop)
+	require.Contains(t, m.labelLastSeen, skKeep)
+}
+
+func TestEvictStaleLabels_KeepFreshLabel(t *testing.T) {
+	t.Parallel()
+	g := prometheus.NewGaugeVec(prometheus.GaugeOpts{Name: "test_evict_keep", Help: "h"}, []string{"job"})
+	reg := prometheus.NewPedanticRegistry()
+	require.NoError(t, reg.Register(g))
+
+	names := []string{"job"}
+	now := time.Now()
+	skFresh := labelsToStorageKey(names, []string{"fresh"})
+
+	m := &Metric{
+		Collector:     g,
+		LabelNames:    names,
+		Name:          "test_evict_keep",
+		labelLastSeen: map[string]time.Time{skFresh: now.Add(-time.Second)},
+	}
+	g.WithLabelValues("fresh").Set(1)
+
+	m.evictStaleLabels(now, time.Minute)
+
+	require.Equal(t, 1, countVecMetrics(reg))
+	require.Contains(t, m.labelLastSeen, skFresh)
+	pb := &dto.Metric{}
+	v, err := g.GetMetricWithLabelValues("fresh")
+	require.NoError(t, err)
+	require.NoError(t, v.Write(pb))
+	require.Equal(t, 1.0, pb.GetGauge().GetValue())
+}
+
+func TestEvictStaleLabels_NoOpWhenTTLZero(t *testing.T) {
+	t.Parallel()
+	g := prometheus.NewGaugeVec(prometheus.GaugeOpts{Name: "test_evict_zero", Help: "h"}, []string{"job"})
+	reg := prometheus.NewPedanticRegistry()
+	require.NoError(t, reg.Register(g))
+
+	names := []string{"job"}
+	now := time.Now()
+	skOld := labelsToStorageKey(names, []string{"old"})
+
+	m := &Metric{
+		Collector:     g,
+		LabelNames:    names,
+		Name:          "test_evict_zero",
+		labelLastSeen: map[string]time.Time{skOld: now.Add(-time.Hour)},
+	}
+	g.WithLabelValues("old").Set(1)
+
+	m.evictStaleLabels(now, 0)
+
+	require.Equal(t, 1, countVecMetrics(reg))
+	require.Contains(t, m.labelLastSeen, skOld)
+}
+
+func TestEvictStaleLabels_ZeroDimensionSkipped(t *testing.T) {
+	t.Parallel()
+	m := &Metric{
+		LabelNames:    nil,
+		Name:          "test_evict_zero_dim",
+		labelLastSeen: nil,
+	}
+	require.NotPanics(t, func() {
+		m.evictStaleLabels(time.Now(), time.Minute)
+	})
+}

--- a/internal/prometheus/vec_labels.go
+++ b/internal/prometheus/vec_labels.go
@@ -4,6 +4,36 @@ import (
 	"encoding/json"
 
 	"github.com/prometheus/client_golang/prometheus"
+	"github.com/prometheus/client_golang/prometheus/promauto"
+	"github.com/vinted/graphql-exporter/internal/config"
+)
+
+// evictedTotal counts label combinations removed from a user metric's vec by TTL eviction.
+// trackedLabels reports the current size of labelLastSeen per user metric (steady-state cardinality
+// once eviction reaches equilibrium).
+//
+// Both are registered on prometheus.DefaultRegisterer (via promauto) and exposed by the same
+// /metrics handler as the user metrics. They are written to only when TTL eviction is active,
+// so with unusedLabelTTLSeconds=0 they emit no series.
+var (
+	evictedTotal = promauto.NewCounterVec(
+		prometheus.CounterOpts{
+			Namespace: config.PrometheusNamespace,
+			Subsystem: "exporter",
+			Name:      "evicted_labels_total",
+			Help:      "Label combinations removed from a user metric's vec by the TTL eviction policy.",
+		},
+		[]string{"metric"},
+	)
+	trackedLabels = promauto.NewGaugeVec(
+		prometheus.GaugeOpts{
+			Namespace: config.PrometheusNamespace,
+			Subsystem: "exporter",
+			Name:      "tracked_labels",
+			Help:      "Current size of the label-last-seen map per user metric.",
+		},
+		[]string{"metric"},
+	)
 )
 
 // labelsToStorageKey encodes label names and values as a stable string for map[...]time.Time.

--- a/internal/prometheus/vec_labels.go
+++ b/internal/prometheus/vec_labels.go
@@ -1,0 +1,62 @@
+package prometheus
+
+import (
+	"encoding/json"
+
+	"github.com/prometheus/client_golang/prometheus"
+)
+
+// labelsToStorageKey encodes label names and values as a stable string for map[...]time.Time.
+// It uses prometheus.Labels (map name → value); json.Marshal sorts object keys, so the key is deterministic.
+// Zero dimensions use "{}" (empty JSON object). Returns "" if len(names) != len(values).
+func labelsToStorageKey(labelNames, labelValues []string) string {
+	if len(labelNames) != len(labelValues) {
+		return ""
+	}
+	if len(labelNames) == 0 {
+		return "{}"
+	}
+	lb := make(prometheus.Labels, len(labelNames))
+	for i := range labelNames {
+		lb[labelNames[i]] = labelValues[i]
+	}
+	b, err := json.Marshal(lb)
+	if err != nil {
+		return ""
+	}
+	return string(b)
+}
+
+// labelValuesFromStorageKey decodes a key from labelsToStorageKey into the slice order expected by
+// WithLabelValues / DeleteLabelValues for this metric's labelNames.
+func labelValuesFromStorageKey(labelNames []string, key string) []string {
+	if key == "" || key == "{}" {
+		return nil
+	}
+	var lb prometheus.Labels
+	if json.Unmarshal([]byte(key), &lb) != nil {
+		return nil
+	}
+	out := make([]string, len(labelNames))
+	for i, n := range labelNames {
+		v, ok := lb[n]
+		if !ok {
+			return nil
+		}
+		out[i] = v
+	}
+	return out
+}
+
+func vecDeleteLabelValues(c prometheus.Collector, lvs []string) bool {
+	switch v := c.(type) {
+	case *prometheus.HistogramVec:
+		return v.DeleteLabelValues(lvs...)
+	case *prometheus.GaugeVec:
+		return v.DeleteLabelValues(lvs...)
+	case *prometheus.CounterVec:
+		return v.DeleteLabelValues(lvs...)
+	default:
+		return false
+	}
+}

--- a/internal/prometheus/vec_labels_test.go
+++ b/internal/prometheus/vec_labels_test.go
@@ -36,6 +36,16 @@ func TestLabelsStorageKeyMismatch(t *testing.T) {
 	require.Equal(t, "", labelsToStorageKey([]string{"a"}, []string{"x", "y"}))
 }
 
+func TestLabelValuesFromStorageKey_UnknownName(t *testing.T) {
+	t.Parallel()
+	// key encodes {"a":"x"} but we ask for ["a","b"] → "b" is absent → nil.
+	names := []string{"a"}
+	key := labelsToStorageKey(names, []string{"x"})
+	require.NotEmpty(t, key)
+	got := labelValuesFromStorageKey([]string{"a", "b"}, key)
+	require.Nil(t, got)
+}
+
 func countVecMetrics(reg prometheus.Gatherer) int {
 	mfs, err := reg.Gather()
 	if err != nil {

--- a/internal/prometheus/vec_labels_test.go
+++ b/internal/prometheus/vec_labels_test.go
@@ -1,0 +1,84 @@
+package prometheus
+
+import (
+	"testing"
+	"time"
+
+	"github.com/prometheus/client_golang/prometheus"
+	dto "github.com/prometheus/client_model/go"
+	"github.com/stretchr/testify/require"
+)
+
+func TestLabelsStorageKeyRoundTrip(t *testing.T) {
+	t.Parallel()
+	names := []string{"job", "stage", "ref"}
+	cases := [][]string{
+		{"a", "b", "c"},
+		{"", "", ""},
+		{`foo"bar`, "x\ny", "refs/heads/main"},
+	}
+	for _, values := range cases {
+		key := labelsToStorageKey(names, values)
+		require.NotEmpty(t, key)
+		got := labelValuesFromStorageKey(names, key)
+		require.Equal(t, values, got, "key=%s", key)
+	}
+}
+
+func TestLabelsStorageKeyZeroDimensions(t *testing.T) {
+	t.Parallel()
+	require.Equal(t, "{}", labelsToStorageKey(nil, nil))
+	require.Empty(t, labelValuesFromStorageKey(nil, "{}"))
+}
+
+func TestLabelsStorageKeyMismatch(t *testing.T) {
+	t.Parallel()
+	require.Equal(t, "", labelsToStorageKey([]string{"a"}, []string{"x", "y"}))
+}
+
+func countVecMetrics(reg prometheus.Gatherer) int {
+	mfs, err := reg.Gather()
+	if err != nil {
+		return -1
+	}
+	n := 0
+	for _, mf := range mfs {
+		n += len(mf.Metric)
+	}
+	return n
+}
+
+func TestEvictStaleLabels_GaugeVec(t *testing.T) {
+	t.Parallel()
+	g := prometheus.NewGaugeVec(prometheus.GaugeOpts{Name: "test_evict_gauge", Help: "h"}, []string{"job"})
+	reg := prometheus.NewPedanticRegistry()
+	require.NoError(t, reg.Register(g))
+
+	names := []string{"job"}
+	now := time.Now()
+	skKeep := labelsToStorageKey(names, []string{"keep"})
+	skDrop := labelsToStorageKey(names, []string{"drop"})
+	require.NotEmpty(t, skKeep)
+	require.NotEmpty(t, skDrop)
+
+	m := &Metric{
+		Collector:     g,
+		LabelNames:    names,
+		labelLastSeen: make(map[string]time.Time),
+	}
+	m.labelLastSeen[skKeep] = now.Add(-time.Minute)
+	m.labelLastSeen[skDrop] = now.Add(-time.Hour)
+	g.WithLabelValues("keep").Set(1)
+	g.WithLabelValues("drop").Set(2)
+
+	require.Equal(t, 2, countVecMetrics(reg))
+
+	m.evictStaleLabels(now, 30*time.Minute)
+
+	require.Equal(t, 1, countVecMetrics(reg))
+	pb := &dto.Metric{}
+	v, err := g.GetMetricWithLabelValues("keep")
+	require.NoError(t, err)
+	require.NoError(t, v.Write(pb))
+	require.Equal(t, 1.0, pb.GetGauge().GetValue())
+}


### PR DESCRIPTION
## Summary

- Adds `unusedLabelTTLSeconds` config field. When >0, label combinations not seen in any successful, error-free scrape for that long are deleted from the vec (per-child `DeleteLabelValues`, not vec-wide `Reset`).
- Exposes two observability metrics under the `ubbleai_graphql_exporter_exporter_` prefix: `evicted_labels_total{metric}` (counter) and `tracked_labels{metric}` (gauge).
- Zero-dimension metrics bypass tracking (no churn).
- Eviction is skipped whenever the GraphQL response contains errors, so partial outages don't purge legitimate labels.
- Chart bumped to `0.1.6` / appVersion `1.0.4`.

## Motivation

[IDVSOL-1130](https://checkout.atlassian.net/browse/IDVSOL-1130): GitLab GraphQL responses include high-cardinality labels (`pipeline_ref`, `job_name`, …) that accumulate unbounded in the exporter's vecs. Memory and `/metrics` payload grow over time, eventually causing scrape timeouts. Increasing the scrape timeout (already done) does not fix the underlying leak.

## Behaviour

- Default `unusedLabelTTLSeconds=0` is a no-op — no map allocation, no observability series, no behavioural change for existing users.
- Eviction runs only when the GraphQL query returned no errors AND data is non-nil — partial errors do not trigger purging.
- Per-child eviction preserves accumulated counter state for non-evicted series; only stale label combinations are removed.

## Known limitations

- The two observability metrics live on `prometheus.DefaultRegisterer` and are exposed by `Start()` (scrape mode). They are NOT included in `Push()` payloads (pushgateway mode), since only the `GraphqlCollector` is pushed there.
- Counter resets on label re-appearance (a label that was evicted then seen again starts from zero). PromQL `rate()` and `increase()` handle counter resets natively.

## Test plan

- [x] `go test ./... -race -count=1` — all PASS
- [x] `go vet ./...` — clean
- [x] `go build ./...` — clean
- [ ] Tag `v1.0.4` after merge
- [ ] Bump Flux pin in downstream devops repo (`k8s/bases/flux2/sources/git-repositories/graphql-exporter.yaml`)
- [ ] Add `unusedLabelTTLSeconds: 21600` to downstream `helmrelease.yaml` (staging first)
- [ ] On staging: confirm `ubbleai_graphql_exporter_exporter_tracked_labels` plateaus and `rate(...evicted_labels_total[1h]) > 0`
- [ ] Confirm `scrape_duration_seconds{job="graphql-exporter"}` stops drifting upward
- [ ] Promote to production