### PR TITLE
chore: release v1.0.5 — chart image.tag aligned with appVersion

### DIFF
--- a/charts/graphql-exporter/Chart.yaml
+++ b/charts/graphql-exporter/Chart.yaml
@@ -15,10 +15,10 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.1.6
+version: 0.1.7
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to
 # follow Semantic Versioning. They should reflect the version the application is using.
 # It is recommended to use it with quotes.
-appVersion: "1.0.4"
+appVersion: "1.0.5"

--- a/charts/graphql-exporter/values.yaml
+++ b/charts/graphql-exporter/values.yaml
@@ -11,7 +11,7 @@ image:
   # This sets the pull policy for images.
   pullPolicy: IfNotPresent
   # Overrides the image tag whose default is the chart appVersion.
-  tag: "v1.0.3"
+  tag: "v1.0.5"
 
 # This is for the secretes for pulling an image from a private repository more information can be found here: https://kubernetes.io/docs/tasks/configure-pod-container/pull-image-private-registry/
 imagePullSecrets: []


### PR DESCRIPTION
## Summary
- Chart `values.yaml` default `image.tag` was left at `v1.0.3` in the v1.0.4 release, so consumers pinning the GitRepository ref to v1.0.4 still pulled the v1.0.3 image
- Bump everything to v1.0.5 to realign chart default, appVersion, and image tag

## Changes
- Chart version: `0.1.6` → `0.1.7`
- `appVersion`: `1.0.4` → `1.0.5`
- `image.tag` (chart default): `v1.0.3` → `v1.0.5`

## Notes
No Go code changes between v1.0.4 and v1.0.5 — the binary is identical, only the chart default tag changes.